### PR TITLE
Scrolling helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ yarn test --watchAll # run tests
 
 ## TODO
 
-* Scrolling behavior - tiles & lines: https://wiki.nesdev.com/w/index.php/PPU_scrolling#Wrapping_around
 * OAM DMA: https://wiki.nesdev.com/w/index.php/PPU_programmer_reference#OAM_DMA_.28.244014.29_.3E_write
 * Sprite zero hit: https://wiki.nesdev.com/w/index.php?title=PPU_OAM&redirect=no#Sprite_zero_hits
 * Sprite priority: https://wiki.nesdev.com/w/index.php/PPU_sprite_priority

--- a/__tests__/ppu_test.re
+++ b/__tests__/ppu_test.re
@@ -199,4 +199,25 @@ describe("PPU", () => {
       expect((nt1, nt2, nt3, nt4)) |> toEqual((0x42, 0x442, 0x42, 0x442));
     });
   });
+
+  describe("scrolling helpers", () => {
+    test("next tile increments coarse_x", () => {
+      let prev = regs.ppu_address land 0x1f;
+      Ppu.next_tile(ppu);
+      expect(regs.ppu_address land 0x1f) |> toEqual(prev + 1);
+    });
+
+    test("next tile wraps to the next nametable appropriately", () => {
+      regs.ppu_address = 0b0010011111;
+      regs.control = 0b10000000;
+      Ppu.next_tile(ppu);
+      let coarse_x = regs.ppu_address land 0x1f;
+      let nt_index = regs.control land 0x3;
+      expect((coarse_x, nt_index)) |> toEqual((0, 1));
+    });
+
+    test("next scanline", () =>
+      expect(true) |> toBe(true)
+    );
+  });
 });

--- a/__tests__/ppu_test.re
+++ b/__tests__/ppu_test.re
@@ -128,17 +128,8 @@ describe("PPU", () => {
       // Second byte.
       Ppu.store(ppu, 0x2005, 0b11000100);
       let latch2 = regs.write_latch;
-      let scroll =
-        Ppu.Scroll.from_registers(regs.buffer, regs.control, regs.fine_x);
-      expect((
-        latch1,
-        latch2,
-        scroll.coarse_x,
-        scroll.fine_x,
-        scroll.coarse_y,
-        scroll.fine_y,
-      ))
-      |> toEqual((true, false, 0b00111, 0b011, 0b11000, 0b100));
+      expect((latch1, latch2, regs.buffer, regs.control, regs.fine_x))
+      |> toEqual((true, false, 0b100001100000111, 0b10001010, 0b011));
     });
 
     test("storing to PPUADDR", () => {
@@ -200,48 +191,12 @@ describe("PPU", () => {
     });
   });
 
-  describe("scrolling helpers", () => {
-    test("next tile increments coarse_x", () => {
-      let prev = regs.ppu_address land 0x1f;
-      Ppu.next_tile(ppu);
-      expect(regs.ppu_address land 0x1f) |> toEqual(prev + 1);
-    });
-
-    test("next tile wraps to the next nametable appropriately", () => {
-      regs.ppu_address = 0b0010011111;
-      regs.control = 0b10000000;
-      Ppu.next_tile(ppu);
-      let coarse_x = regs.ppu_address land 0x1f;
-      let nt_index = regs.control land 0x3;
-      expect((coarse_x, nt_index)) |> toEqual((0, 1));
-    });
-
-    test("next scanline increments fine_y", () => {
-      regs.ppu_address = 0b010000000000000;
-      Ppu.next_scanline(ppu);
-      expect(regs.ppu_address) |> toEqual(0b011000000000000);
-    });
-
-    test("next scanline wraps to increment coarse_y appropriately", () => {
-      regs.ppu_address = 0b111001110000000;
-      Ppu.next_scanline(ppu);
-      expect(regs.ppu_address) |> toEqual(0b000001110100000);
-    });
-
-    test("next scanline wraps to the next nametable appropriately", () => {
-      regs.ppu_address = 0b111001110100000;
-      regs.control = 0b10000000;
-      Ppu.next_scanline(ppu);
-      expect((regs.ppu_address, regs.control)) |> toEqual((0, 0b10000010));
-    });
-  });
-
   describe("scrolling", () => {
-    test("we create Scroll from registers correctly", () => {
+    test("we create ScrollInfo from registers correctly", () => {
       let address = 0b010001111001111;
       let control = 0b10000001;
-      let scroll = Ppu.Scroll.from_registers(address, control, 5);
-      let result: Ppu.Scroll.t = {
+      let scroll = Ppu.ScrollInfo.from_registers(address, control, 5);
+      let result: Ppu.ScrollInfo.t = {
         nt_index: 0b01,
         coarse_x: 0b01111,
         coarse_y: 0b11110,
@@ -252,54 +207,67 @@ describe("PPU", () => {
     });
 
     test("next_tile advances the coarse_x position", () => {
-      let scroll = Ppu.Scroll.from_registers(0b0000000011110, 0, 0);
-      let result: Ppu.Scroll.t = {
+      let scroll = Ppu.ScrollInfo.from_registers(0b0000000011110, 0, 0);
+      let result: Ppu.ScrollInfo.t = {
         nt_index: 0b00,
         coarse_x: 0b11111,
         coarse_y: 0b00000,
         fine_x: 0,
         fine_y: 0b000,
       };
-      Ppu.Scroll.next_tile(scroll);
+      Ppu.ScrollInfo.next_tile(scroll);
       expect(scroll) |> toEqual(result);
     });
 
     test("next_tile wraps to the next horizontal nametable", () => {
-      let scroll = Ppu.Scroll.from_registers(0b0000000011111, 0, 0);
-      let result: Ppu.Scroll.t = {
+      let scroll = Ppu.ScrollInfo.from_registers(0b0000000011111, 0, 0);
+      let result: Ppu.ScrollInfo.t = {
         nt_index: 0b01,
         coarse_x: 0b00000,
         coarse_y: 0b00000,
         fine_x: 0,
         fine_y: 0b000,
       };
-      Ppu.Scroll.next_tile(scroll);
+      Ppu.ScrollInfo.next_tile(scroll);
       expect(scroll) |> toEqual(result);
     });
 
     test("next_scanline bumps the fine_y position", () => {
-      let scroll = Ppu.Scroll.from_registers(0b110000000000000, 0, 0);
-      let result: Ppu.Scroll.t = {
+      let scroll = Ppu.ScrollInfo.from_registers(0b110000000000000, 0, 0);
+      let result: Ppu.ScrollInfo.t = {
         nt_index: 0b00,
         coarse_x: 0b00000,
         coarse_y: 0b00000,
         fine_x: 0,
         fine_y: 0b111,
       };
-      Ppu.Scroll.next_scanline(scroll);
+      Ppu.ScrollInfo.next_scanline(scroll);
       expect(scroll) |> toEqual(result);
     });
 
     test("next_scanline wraps fine_y to coarse_y appropriately", () => {
-      let scroll = Ppu.Scroll.from_registers(0b111000000000000, 0, 0);
-      let result: Ppu.Scroll.t = {
+      let scroll = Ppu.ScrollInfo.from_registers(0b111000000000000, 0, 0);
+      let result: Ppu.ScrollInfo.t = {
         nt_index: 0b00,
         coarse_x: 0b00000,
         coarse_y: 0b00001,
         fine_x: 0,
         fine_y: 0b000,
       };
-      Ppu.Scroll.next_scanline(scroll);
+      Ppu.ScrollInfo.next_scanline(scroll);
+      expect(scroll) |> toEqual(result);
+    });
+
+    test("next_scanline wraps to the next vertical nametable", () => {
+      let scroll = Ppu.ScrollInfo.from_registers(0b111001110100000, 1, 0);
+      let result: Ppu.ScrollInfo.t = {
+        nt_index: 0b11,
+        coarse_x: 0b00000,
+        coarse_y: 0b00000,
+        fine_x: 0,
+        fine_y: 0b000,
+      };
+      Ppu.ScrollInfo.next_scanline(scroll);
       expect(scroll) |> toEqual(result);
     });
   });

--- a/__tests__/ppu_test.re
+++ b/__tests__/ppu_test.re
@@ -216,8 +216,23 @@ describe("PPU", () => {
       expect((coarse_x, nt_index)) |> toEqual((0, 1));
     });
 
-    test("next scanline", () =>
-      expect(true) |> toBe(true)
-    );
+    test("next scanline increments fine_y", () => {
+      regs.ppu_address = 0b010000000000000;
+      Ppu.next_scanline(ppu);
+      expect(regs.ppu_address) |> toEqual(0b011000000000000);
+    });
+
+    test("next scanline wraps to increment coarse_y appropriately", () => {
+      regs.ppu_address = 0b111001110000000;
+      Ppu.next_scanline(ppu);
+      expect(regs.ppu_address) |> toEqual(0b000001110100000);
+    });
+
+    test("next scanline wraps to the next nametable appropriately", () => {
+      regs.ppu_address = 0b111001110100000;
+      regs.control = 0b10000000;
+      Ppu.next_scanline(ppu);
+      expect((regs.ppu_address, regs.control)) |> toEqual((0, 0b10000010));
+    });
   });
 });

--- a/__tests__/ppu_test.re
+++ b/__tests__/ppu_test.re
@@ -235,4 +235,72 @@ describe("PPU", () => {
       expect((regs.ppu_address, regs.control)) |> toEqual((0, 0b10000010));
     });
   });
+
+  describe("scrolling", () => {
+    test("we create Scroll from registers correctly", () => {
+      let address = 0b010001111001111;
+      let control = 0b10000001;
+      let scroll = Ppu.Scroll.from_registers(address, control, 5);
+      let result: Ppu.Scroll.t = {
+        nt_index: 0b01,
+        coarse_x: 0b01111,
+        coarse_y: 0b11110,
+        fine_x: 5,
+        fine_y: 0b010,
+      };
+      expect(scroll) |> toEqual(result);
+    });
+
+    test("next_tile advances the coarse_x position", () => {
+      let scroll = Ppu.Scroll.from_registers(0b0000000011110, 0, 0);
+      let result: Ppu.Scroll.t = {
+        nt_index: 0b00,
+        coarse_x: 0b11111,
+        coarse_y: 0b00000,
+        fine_x: 0,
+        fine_y: 0b000,
+      };
+      Ppu.Scroll.next_tile(scroll);
+      expect(scroll) |> toEqual(result);
+    });
+
+    test("next_tile wraps to the next horizontal nametable", () => {
+      let scroll = Ppu.Scroll.from_registers(0b0000000011111, 0, 0);
+      let result: Ppu.Scroll.t = {
+        nt_index: 0b01,
+        coarse_x: 0b00000,
+        coarse_y: 0b00000,
+        fine_x: 0,
+        fine_y: 0b000,
+      };
+      Ppu.Scroll.next_tile(scroll);
+      expect(scroll) |> toEqual(result);
+    });
+
+    test("next_scanline bumps the fine_y position", () => {
+      let scroll = Ppu.Scroll.from_registers(0b110000000000000, 0, 0);
+      let result: Ppu.Scroll.t = {
+        nt_index: 0b00,
+        coarse_x: 0b00000,
+        coarse_y: 0b00000,
+        fine_x: 0,
+        fine_y: 0b111,
+      };
+      Ppu.Scroll.next_scanline(scroll);
+      expect(scroll) |> toEqual(result);
+    });
+
+    test("next_scanline wraps fine_y to coarse_y appropriately", () => {
+      let scroll = Ppu.Scroll.from_registers(0b111000000000000, 0, 0);
+      let result: Ppu.Scroll.t = {
+        nt_index: 0b00,
+        coarse_x: 0b00000,
+        coarse_y: 0b00001,
+        fine_x: 0,
+        fine_y: 0b000,
+      };
+      Ppu.Scroll.next_scanline(scroll);
+      expect(scroll) |> toEqual(result);
+    });
+  });
 });

--- a/src/Ppu.re
+++ b/src/Ppu.re
@@ -206,3 +206,13 @@ let store = (ppu: t, address, value) =>
   | 7 => write_vram(ppu, value)
   | _ => ()
   };
+
+let next_tile = ppu => {
+  let new_coarse_x = ppu.registers.ppu_address + 1;
+  if (new_coarse_x land 0x1f == 0) {
+    ppu.registers.ppu_address = new_coarse_x land 0x1f;
+    ppu.registers.control = ppu.registers.control lxor 1;
+  } else {
+    ppu.registers.ppu_address = new_coarse_x;
+  };
+};

--- a/src/Ppu.re
+++ b/src/Ppu.re
@@ -151,11 +151,11 @@ let write_oam = (ppu: t, value) => {
 
 module Scroll = {
   type t = {
-    nt_index: int,
-    coarse_x: int,
-    coarse_y: int,
-    fine_x: int,
-    fine_y: int,
+    mutable nt_index: int,
+    mutable coarse_x: int,
+    mutable coarse_y: int,
+    mutable fine_x: int,
+    mutable fine_y: int,
   };
 
   let from_registers = (base, control, fine_x): t => {
@@ -165,6 +165,26 @@ module Scroll = {
     fine_x,
     fine_y: base lsr 12,
   };
+
+  let next_tile = scroll =>
+    if (scroll.coarse_x == 31) {
+      scroll.coarse_x = 0;
+      scroll.nt_index = scroll.nt_index lxor 1;
+    } else {
+      scroll.coarse_x = scroll.coarse_x + 1;
+    };
+
+  let next_scanline = scroll =>
+    switch (scroll.fine_y == 7, scroll.coarse_y == 29) {
+    | (true, true) =>
+      scroll.fine_y = 0;
+      scroll.coarse_y = 0;
+      scroll.nt_index = scroll.nt_index lxor 2;
+    | (true, false) =>
+      scroll.fine_y = 0;
+      scroll.coarse_y = scroll.coarse_y + 1;
+    | (false, _) => scroll.fine_y = scroll.fine_y + 1
+    };
 };
 
 let write_scroll = (ppu: t, value) => {

--- a/src/Ppu.re
+++ b/src/Ppu.re
@@ -170,9 +170,10 @@ let store = (ppu: t, address, value) =>
    The 15-bit buffer register, `t`, must receive two writes before forming a completed address.
    Two different interfaces are exposed for the comfort of the application programmer:
 
-   1. The PPUSTATUS interface at $2005 for setting the scroll position of the next frame.
+   1. The PPUSCROLL interface at $2005 for setting the scroll position of the next frame.
      * Each byte it receives specifies either the coarse x and fine x or coarse y and fine y coordinates.
      * It can be written to at any point during vblank and will copy `t` to `v` just before rendering.
+     * It can also be written to during hblank for mid-frame raster effects.
    2. The PPUADDR interface at $2006 for updating the address before using PPUDATA to read/write VRAM.
      * Each byte it receives is either the low byte or high byte for the buffer.
      * It immediately copies `t` to `v` after the second write.

--- a/src/Ppu.re
+++ b/src/Ppu.re
@@ -180,14 +180,6 @@ let store = (ppu: t, address, value) =>
 
    The current value of the buffer is copied to the address register during the last vblank scanline.
    During rendering, the address register is updated by the PPU to reflect the current memory access.
-
-   Since there are not actually separate registers for scrolling information,
-   and either `ppu_address` or the `buffer` could be viewed as the source of scrolling info,
-   we have written a module below which accepts one of these registers and interprets the bitfield
-   as described in the above documentation. It is _possible_ that we could dispense with the existence
-   of the buffer entirely and let the programmer directly write to the address register if we are
-   confident that no applications would try to interleave writes to PPUSCROLL and PPUADDR.
-   I struggle to imagine an observable scenario where the two would be out of sync otherwise.
  */
 
 module ScrollInfo = {


### PR DESCRIPTION
See: https://wiki.nesdev.com/w/index.php/PPU_scrolling#Wrapping_around

Added some helper functions for updating the Ppu's address and control registers $2002 and $2006 appropriately during rendering (i.e. to progress to the next tile or scanline). Note that we deviate _slightly_ from the docs by using the bottom 2 bits of the control register for nametable selection rather than clobbering those bits in the ppu_address.

It's possible that this should be an entirely render-level concern and the interface we really want is to have a Scroll record that we update periodically based on these same rules. 🤔I am not entirely confident what might depend on the ppu_address register updating _during_ rendering. My hope would be "not many games". I'll probably distract myself this afternoon by implementing MMC1 or looking at synths instead. 😎