### PR TITLE
Render nametable

### DIFF
--- a/__tests__/render_test.re
+++ b/__tests__/render_test.re
@@ -108,32 +108,32 @@ describe("Render", () => {
     test("can detect top left quadrants using the scroll", () => {
       let s1 = builder(0, 0);
       let s2 = builder(1, 1);
-      let q1 = Render.ScrollInfo.quad_position(s1);
-      let q2 = Render.ScrollInfo.quad_position(s2);
+      let q1 = Render.ScrollInfo.quad_position(0, 0);
+      let q2 = Render.ScrollInfo.quad_position(1, 1);
       expect([q1, q2]) |> toEqual([TopLeft, TopLeft]);
     });
 
     test("can detect top right quadrants using the scroll", () => {
       let s1 = builder(2, 0);
       let s2 = builder(3, 1);
-      let q1 = Render.ScrollInfo.quad_position(s1);
-      let q2 = Render.ScrollInfo.quad_position(s2);
+      let q1 = Render.ScrollInfo.quad_position(2, 0);
+      let q2 = Render.ScrollInfo.quad_position(3, 1);
       expect([q1, q2]) |> toEqual([TopRight, TopRight]);
     });
 
     test("can detect bottom left quadrants using the scroll", () => {
       let s1 = builder(0, 2);
       let s2 = builder(1, 3);
-      let q1 = Render.ScrollInfo.quad_position(s1);
-      let q2 = Render.ScrollInfo.quad_position(s2);
+      let q1 = Render.ScrollInfo.quad_position(0, 2);
+      let q2 = Render.ScrollInfo.quad_position(1, 3);
       expect([q1, q2]) |> toEqual([BottomLeft, BottomLeft]);
     });
 
     test("can detect bottom right quadrants using the scroll", () => {
       let s1 = builder(2, 2);
       let s2 = builder(3, 3);
-      let q1 = Render.ScrollInfo.quad_position(s1);
-      let q2 = Render.ScrollInfo.quad_position(s2);
+      let q1 = Render.ScrollInfo.quad_position(2, 2);
+      let q2 = Render.ScrollInfo.quad_position(3, 3);
       expect([q1, q2]) |> toEqual([BottomRight, BottomRight]);
     });
   });


### PR DESCRIPTION
A small feature that required a little more change than expected. PS: We took 2 months off cause we got married. :grin: :tada:

1. We made the render context a record type so we could frob things and peek at state when needed (debugging tools). We may turn this into some sort of Context monad in the future since we're manually threading the state recently and it's a little gross.

2. Add a `render_nametable` function so `Render.Context.render_nametable(nes.render, 1)` is possible.