### PR TITLE
Rip out the Pattern Table cache.

### DIFF
--- a/src/Nes.re
+++ b/src/Nes.re
@@ -18,7 +18,7 @@ let load = (rom: Rom.t): t => {
   Cpu.reset(cpu);
 
   let ppu = memory.ppu;
-  let render = Render.Context.make(ppu, rom, ~on_nmi=() => Cpu.nmi(cpu));
+  let render = Render.Context.make(ppu, ~on_nmi=() => Cpu.nmi(cpu));
 
   {cpu, ppu, rom, gamepad, render, frame: [||]};
 };

--- a/src/Pattern.re
+++ b/src/Pattern.re
@@ -28,6 +28,9 @@ module Tile = {
     };
   };
 
+  let line_bits = (low, high) =>
+    Array.init(8, x => { high lsr (7 - x) land 1 * 2 + low lsr (7 - x) land 1 })
+
   let inspect = (tile: t, format: int => string): string => {
     let result = ref("");
 

--- a/src/Ppu.re
+++ b/src/Ppu.re
@@ -58,9 +58,9 @@ let sprite_address = ctrl_helper(3, 0, 0x1000);
 let background_address = ctrl_helper(4, 0, 0x1000);
 let vblank_nmi = ctrl_helper(7, NMIDisabled, NMIEnabled);
 
-let sprite_offset = ppu => Util.read_bit(ppu.registers.control, 3) ? 256 : 0;
+let sprite_offset = ppu => Util.read_bit(ppu.registers.control, 3) ? 0x1000 : 0;
 let background_offset = ppu =>
-  Util.read_bit(ppu.registers.control, 4) ? 256 : 0;
+  Util.read_bit(ppu.registers.control, 4) ? 0x1000 : 0;
 
 let show_background_left = mask_helper(1);
 let show_sprites_left = mask_helper(2);
@@ -83,10 +83,11 @@ let nt_offset = nt_index => 0x2000 + nt_index * 0x400;
 let nt_mirror = (ppu, address) => {
   let mirroring = ppu.pattern_table.mirroring();
   // Bit 11 indicates we're reading from nametables 3 and 4, i.e. 2800 and 2C00.
+  // TODO: Support Upper and Lower mirroring.
   switch (mirroring, Util.read_bit(address, 11)) {
   | (Rom.Horizontal, false) => address land 0x3ff
   | (Rom.Horizontal, true) => 0x400 + address land 0x3ff
-  | (Rom.Vertical, _) => address land 0x7ff
+  | _ => address land 0x7ff // Vertical
   };
 };
 

--- a/src/Sprite.re
+++ b/src/Sprite.re
@@ -21,10 +21,8 @@ module Tile = {
   let flip_hori = sprite => Util.read_bit(sprite.attributes, 6);
   let flip_vert = attr_byte => Util.read_bit(attr_byte, 7);
   let high_bits = sprite => sprite.attributes land 0x3;
-  let line_bits = (sprite, tile, scanline) => {
-    let row = scanline - sprite.y_position;
-    let line = flip_vert(sprite.attributes) ? 7 - row : row;
-    tile[line];
+  let line_bits = (low, high) => {
+    Array.init(8, x => { high lsr (7 - x) land 1 * 2 + low lsr (7 - x) land 1 })
   };
 
   let on_line = (scanline, top_of_sprite) => {


### PR DESCRIPTION
This gets us past our current issues around writes to CHR not being recognized because we never invalidate the pattern table cache.

A re-envisioned TileCache should return at a later time when we want to create something that corresponds to the real graphical elements on screen and start mapping them to WebGL, etc.